### PR TITLE
Store subscriber data

### DIFF
--- a/includes/classes/wp-maintenance-mode.php
+++ b/includes/classes/wp-maintenance-mode.php
@@ -1385,7 +1385,7 @@ if ( ! class_exists( 'WP_Maintenance_Mode' ) ) {
 		 */
 		public function otter_add_subscriber( $form_data ) {
 			if ( $form_data ) {
-				$input_data = $form_data->get_payload_field( 'formInputsData' );
+				$input_data = $form_data->get_data_from_payload( 'formInputsData' );
 				$input_data = array_map(
 					function( $input_field ) {
 						if ( isset( $input_field['type'] ) && 'email' === $input_field['type'] ) {


### PR DESCRIPTION
### Summary
Store the subscriber data while the user submits the form on the Maintenance Mode page.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/wp-maintenance-mode/issues/480