### PR TITLE
Added tracking opt-in checkbox

### DIFF
--- a/assets/css/style-wizard.css
+++ b/assets/css/style-wizard.css
@@ -296,6 +296,19 @@ h2.wpmm-title span img {
     font-size: 18px;
 }
 
+.subscribe-step .opt-in-container {
+    display: flex;
+    gap: 8px;
+    margin-top: 20px;
+}
+
+.subscribe-step .opt-in-container svg.components-checkbox-control__checked {
+    top: 20%;
+}
+
+.subscribe-step .opt-in-container label {
+    text-align: left;
+}
 #email-input-wrap {
     position: relative;
     display: flex;

--- a/assets/js/scripts-admin.js
+++ b/assets/js/scripts-admin.js
@@ -429,11 +429,13 @@ jQuery( function( $ ) {
 
 		emailInput.removeClass( 'invalid' );
 		subscribeButton.addClass( 'is-busy' );
+		const optIn = $('#wizard-opt-in').is( ':checked' );
 
 		$.post( wpmmVars.ajaxURL, {
 			action: 'wpmm_subscribe',
 			email,
 			_wpnonce: wpmmVars.wizardNonce,
+			opt_in: optIn ? 1 : 0,
 		}, function( response ) {
 			if ( ! response.success ) {
 				alert( response.data );

--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -806,7 +806,7 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 				die( esc_html__( 'Empty field: email', 'wp-maintenance-mode' ) );
 			}
 
-			if ( isset( $_POST['opt_in'] ) && $_POST['opt_in'] ) {
+			if ( isset( $_POST['opt_in'] ) && sanitize_text_field( $_POST['opt_in'] ) ) {
 				update_option( 'wp_maintenance_mode_logger_flag', 'yes' );
 			}
 

--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -806,6 +806,10 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 				die( esc_html__( 'Empty field: email', 'wp-maintenance-mode' ) );
 			}
 
+			if ( isset( $_POST['opt_in'] ) && $_POST['opt_in'] ) {
+				update_option( 'wp_maintenance_mode_logger_flag', 'yes' );
+			}
+
 			$response = wp_remote_post(
 				self::SUBSCRIBE_ROUTE,
 				array(

--- a/includes/classes/wp-maintenance-mode.php
+++ b/includes/classes/wp-maintenance-mode.php
@@ -159,6 +159,9 @@ if ( ! class_exists( 'WP_Maintenance_Mode' ) ) {
 					}
 				);
 			}
+
+			add_action( 'init', array( $this, 'initialize_telemetry' ) );
+
 		}
 
 		/**
@@ -1448,6 +1451,35 @@ if ( ! class_exists( 'WP_Maintenance_Mode' ) ) {
 		 */
 		public function get_current_page_category() {
 			return $this->current_page_category;
+		}
+
+		/**
+		 * Initialize telemetry.
+		 *
+		 * @return void
+		 */
+		public function initialize_telemetry() {
+			if ( 'yes' === get_option( 'wp_maintenance_mode_logger_flag' ) ) {
+				add_filter( 'themeisle_sdk_enable_telemetry', '__return_true' );
+				add_filter(
+					'themeisle_sdk_telemetry_products',
+					function( $products ) {
+						$license = get_option( 'visualizer_pro_license_data', 'free' );
+						if ( ! empty( $license ) && is_object( $license ) ) {
+							$license = $license->key;
+						}
+
+						foreach ( $products as &$product ) {
+							if ( isset( $product['slug'] ) && 'wp' === $product['slug'] ) {
+								$product['slug'] = 'wp_maintenance_mode';
+							}
+						}
+
+						return $products;
+					}
+				);
+			}
+
 		}
 	}
 

--- a/includes/classes/wp-maintenance-mode.php
+++ b/includes/classes/wp-maintenance-mode.php
@@ -1464,11 +1464,6 @@ if ( ! class_exists( 'WP_Maintenance_Mode' ) ) {
 				add_filter(
 					'themeisle_sdk_telemetry_products',
 					function( $products ) {
-						$license = get_option( 'visualizer_pro_license_data', 'free' );
-						if ( ! empty( $license ) && is_object( $license ) ) {
-							$license = $license->key;
-						}
-
 						foreach ( $products as &$product ) {
 							if ( isset( $product['slug'] ) && 'wp' === $product['slug'] ) {
 								$product['slug'] = 'wp_maintenance_mode';

--- a/views/wizard.php
+++ b/views/wizard.php
@@ -116,6 +116,13 @@ $default_templates = array(
 					<input type="text" value="<?php echo esc_attr( get_bloginfo( 'admin_email' ) ); ?>" />
 					<input type="button" class="button button-primary button-big subscribe-button" value="<?php esc_attr_e( 'Sign me up', 'wp-maintenance-mode' ); ?>" />
 				</div>
+				<div class="opt-in-container">
+					<span class="components-checkbox-control__input-container">
+						<input id="wizard-opt-in" type="checkbox" class="components-checkbox-control__input" checked>
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="presentation" class="components-checkbox-control__checked" aria-hidden="true" focusable="false"><path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"></path></svg>
+					</span>
+					<label for="wizard-opt-in"><?php echo esc_html__( 'Help us improve LightStart by opting in to anonymous usage tracking. No sensitive data is collected.', 'wp-maintenance-mode' ); ?></label>
+				</div>
 				<input id="skip-subscribe" type="button" class="button button-link skip-link" value="<?php esc_attr_e( 'I\'ll skip for now, thanks!', 'wp-maintenance-mode' ); ?>" />
 			</div>
 		</div>


### PR DESCRIPTION
### Summary
Added an option for tracking opt-in.

### Screenshots
<img width="794" height="809" alt="Screenshot from 2026-02-05 18-44-42" src="https://github.com/user-attachments/assets/a372fa24-3efd-4d96-9193-86471c1191f2" />

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/wp-maintenance-mode/issues/503