### PR TITLE
refactor: change Black Friday label for Neve promotion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# Agent Workflow
+
+## Project Overview
+
+WP Maintenance Mode (LightStart) is a WordPress plugin by Themeisle that displays a maintenance mode, coming soon, or landing page to visitors. Text domain: `wp-maintenance-mode`. Option key: `wpmm_settings`. All constants prefixed with `WPMM_`.
+
+## Commands
+
+```bash
+# Install dependencies
+composer install
+npm install
+
+# Lint (PHP_CodeSniffer with WordPress coding standards)
+composer run lint
+
+# Auto-fix coding standards
+composer run format
+
+# Run PHPUnit tests
+./vendor/bin/phpunit
+
+# Run a single test file
+./vendor/bin/phpunit tests/generic-test.php
+
+# Build assets (minify JS + CSS via Grunt)
+npm run build        # or: npx grunt
+
+# Watch for asset changes during development
+npx grunt watch
+```
+
+## Architecture
+
+### Entry Point & Bootstrap
+
+`wp-maintenance-mode.php` — Main plugin file. Defines all `WPMM_*` constants (paths, URLs), requires function files, then loads the two core singleton classes via `plugins_loaded`.
+
+### Core Classes (`includes/classes/`)
+
+- **`WP_Maintenance_Mode`** — Frontend singleton. Handles maintenance mode display logic, page templates, redirect rules, multisite/network mode support, and shortcode registration. Loaded on every request.
+- **`WP_Maintenance_Mode_Admin`** — Admin singleton. Settings page, AJAX handlers (prefixed `wp_ajax_wpmm_*`), wizard flow, template management, subscriber export, and notices. Only loaded in `is_admin()` context.
+- **`WP_Maintenance_Mode_Shortcodes`** + `shortcodes/` — Shortcode registration (e.g., login form shortcode).
+
+### Functions (`includes/functions/`)
+
+- **`hooks.php`** — Plugin header filters and email content type hook.
+- **`helpers.php`** — Utility functions (e.g., `wpmm_get_option()`).
+
+### Views (`views/`)
+
+PHP template files for admin settings tabs (`settings.php`, `contact.php`, `google-analytics.php`), the frontend maintenance page (`maintenance.php`), wizard (`wizard.php`), network settings, notices, and sidebar.
+
+### Assets
+
+- `assets/js/` — Frontend (`scripts.js`) and admin (`scripts-admin.js`, `scripts-admin-global.js`) JavaScript, plus chatbot (`bot.js`, `bot.async.js`). Grunt minifies to `.min.js`.
+- `assets/css/` — Stylesheets minified via PostCSS/cssnano to `.min.css`.
+- `assets/templates/` — Block template JSON files organized by category: `coming-soon/`, `maintenance/`, `landing-page/`.
+
+### Settings Structure
+
+Plugin settings stored as serialized array in `wpmm_settings` option, with sections: `general` (status, network_mode), plus additional tabs managed by the admin class. Network/multisite settings stored in `wpmm_settings_network`.
+
+## Coding Standards
+
+- WordPress-Core standards enforced via PHPCS (`phpcs.xml`), with specific exclusions (no Yoda conditions required, loose comparison allowed, etc.)
+- i18n text domain: `wp-maintenance-mode`
+- PHP minimum: 7.0 (runtime set in PHPCS)
+- Assets use `.min.` suffix in production; controlled by `SCRIPT_DEBUG` constant

--- a/composer.lock
+++ b/composer.lock
@@ -4,25 +4,25 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5f5da36c50a2fe2bccfce677431bfbc",
+    "content-hash": "6acace5af549ca9a6ced24d8aeef359d",
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.3.48",
+            "version": "3.3.51",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "0727d2cf2fc9bfb81b42968aeaf2bf4e340f021e"
+                "reference": "bb2a8414b0418b18c68c9ff1df3d7fb10467928d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/0727d2cf2fc9bfb81b42968aeaf2bf4e340f021e",
-                "reference": "0727d2cf2fc9bfb81b42968aeaf2bf4e340f021e",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/bb2a8414b0418b18c68c9ff1df3d7fb10467928d",
+                "reference": "bb2a8414b0418b18c68c9ff1df3d7fb10467928d",
                 "shasum": ""
             },
             "require-dev": {
                 "codeinwp/phpcs-ruleset": "dev-main",
-                "yoast/phpunit-polyfills": "^2.0"
+                "yoast/phpunit-polyfills": "^4.0"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
@@ -36,16 +36,16 @@
                     "homepage": "https://themeisle.com"
                 }
             ],
-            "description": "ThemeIsle SDK",
+            "description": "Themeisle SDK.",
             "homepage": "https://github.com/Codeinwp/themeisle-sdk",
             "keywords": [
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.48"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.51"
             },
-            "time": "2025-08-11T16:47:24+00:00"
+            "time": "2026-03-30T07:58:49+00:00"
         }
     ],
     "packages-dev": [
@@ -671,5 +671,5 @@
     "platform-overrides": {
         "php": "5.6"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -1324,15 +1324,13 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 		public function add_black_friday_data( $configs ) {
 			$config = $configs['default'];
 
-			// translators: %1$s - plugin namce, %2$s - HTML tag, %3$s - discount, %4$s - HTML tag, %5$s - company name.
-			$message_template = __( 'Brought to you by the team behind %1$s— our biggest sale of the year is here: %2$sup to %3$s OFF%4$s on premium products from %5$s! Limited-time only.', 'wp-maintenance-mode' );
-
-			$config['message']  = sprintf( $message_template, 'WP Maintenance Mode', '<strong>', '70%', '</strong>', '<strong>Themeisle</strong>' );
+			$config['message']  = __( 'You use LightStart to build your site. Take it further with Neve Pro: starter sites, header builder, WooCommerce layouts. Built by the same team. ', 'wp-maintenance-mode' );
+			$config['cta_label'] = __( 'Get Neve Pro free', 'wp-maintenance-mode' );
 			$config['sale_url'] = add_query_arg(
 				array(
 					'utm_term' => 'free',
 				),
-				tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/all-bf', 'bfcm', 'wp-maintenance-mode' ) )
+				tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/neve-bf', 'bfcm', 'lightstart' ) )
 			);
 
 			$configs[ WPMM_PRODUCT_SLUG ] = $config;

--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -1328,14 +1328,15 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 				return $configs;
 			}
 
-			$config['message']  = __( 'You use LightStart to build your site. Take it further with Neve Pro: starter sites, header builder, WooCommerce layouts. Built by the same team. ', 'wp-maintenance-mode' );
-			$config['cta_label'] = __( 'Get Neve Pro free', 'wp-maintenance-mode' );
+			// translators: 1. Number of free licenses, 2. The price of the product.
+			$config['message']             = sprintf( __( 'You\'re using LightStart, and the team behind it is celebrating Black Friday by giving away %1$s licences of Neve Pro. A premium WordPress theme worth %2$s, packed with starter sites, a header builder, and WooCommerce layouts. Claim yours before they run out.', 'wp-maintenance-mode' ), 100, '$69' );
+			$config['cta_label']           = __( 'Get Neve Pro free', 'wp-maintenance-mode' );
 			$config['plugin_meta_message'] = __( 'Black Friday Sale - Get Neve Pro free', 'wp-maintenance-mode' );
-			$config['sale_url'] = add_query_arg(
+			$config['sale_url']            = add_query_arg(
 				array(
 					'utm_term' => 'free',
 				),
-				tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/neve-bf', 'bfcm', 'lightstart' ) )
+				tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/neve-claim-bf', 'bfcm', 'lightstart' ) )
 			);
 
 			$configs[ WPMM_PRODUCT_SLUG ] = $config;

--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -1324,8 +1324,13 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 		public function add_black_friday_data( $configs ) {
 			$config = $configs['default'];
 
+			if ( defined( 'NEVE_VERSION' ) ) {
+				return $configs;
+			}
+
 			$config['message']  = __( 'You use LightStart to build your site. Take it further with Neve Pro: starter sites, header builder, WooCommerce layouts. Built by the same team. ', 'wp-maintenance-mode' );
 			$config['cta_label'] = __( 'Get Neve Pro free', 'wp-maintenance-mode' );
+			$config['plugin_meta_message'] = __( 'Black Friday Sale - Get Neve Pro free', 'wp-maintenance-mode' );
 			$config['sale_url'] = add_query_arg(
 				array(
 					'utm_term' => 'free',


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Add the labels for Black Friday promotion. Based on https://github.com/Codeinwp/themeisle/issues/1854
- Complete the Formbricks integration

### Screenshots <!-- if applicable -->

<img width="4772" height="2384" alt="CleanShot 2026-04-06 at 12 30 19@2x" src="https://github.com/user-attachments/assets/9b46efd7-5080-4c58-9ba0-c0ff1e67ce41" />


<img width="3330" height="1588" alt="CleanShot 2026-04-06 at 12 12 43@2x" src="https://github.com/user-attachments/assets/a873b98a-1dfb-47e6-a4c0-a7df7991d7c8" />


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this plugin: https://github.com/Soare-Robert-Daniel/test-black-friday
- Use this SDK version: https://github.com/Codeinwp/themeisle-sdk-main/pull/309
- Test:
  - If the notice appears during the Black Friday period.
  - If the labels change based on the license status (described in the spreadsheet)
  - If the notice can be dismissed.
  - If the notice appears only if the plugin is 3 days old. Warning: You will see the notice if you have another product that is older than 3 days; in this case, better to disable them.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/themeisle/issues/1854
<!-- Should look like this: `Closes #1, #2, #3.` . -->
