### PR TITLE
feat: add Super Page Cache option to the onboarding wizard

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           php-version: '7.2'
           extensions: simplexml, mysql
-          tools: phpunit-polyfills
+          tools: phpunit:7.5.20, phpunit-polyfills
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Install Subversion
@@ -73,7 +73,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
       - name: Install composer
-        run: composer install --prefer-dist --no-progress --no-suggest --no-dev
+        run: composer install --prefer-dist --no-progress --no-suggest
       - name: Run phpunit
         run: composer run-script phpunit
-

--- a/assets/css/style-wizard.css
+++ b/assets/css/style-wizard.css
@@ -107,6 +107,7 @@ h2.wpmm-title span img {
 .step.import-step {
     margin: min(10%, 65px) min(12%, 195px);
     width: 1090px;
+    outline: 0;
 }
 
 .import-step .header {

--- a/assets/js/scripts-admin.js
+++ b/assets/js/scripts-admin.js
@@ -601,6 +601,7 @@ jQuery( function( $ ) {
 	 */
 	function handlePlugins() {
 		const optimoleCheckbox = $( '#wizard-optimole-checkbox' );
+		const wpscCheckbox = $( '#wizard-wpsc-checkbox' );
 		const otterBlockCheckbox = $( '#wizard-otter-block-checkbox' );
 		let promiseChain = Promise.resolve();
 
@@ -615,6 +616,19 @@ jQuery( function( $ ) {
 						return activatePlugin( 'optimole-wp' );
 					}
 				});
+		}
+
+		if ( wpscCheckbox.length && wpscCheckbox.is( ':checked' ) ) {
+			promiseChain = promiseChain
+				.then( () => {
+					if ( ! wpmmVars.isWPSCInstalled ) {
+						return installPlugin( 'wp-cloudflare-page-cache' ).then( () => activatePlugin( 'wp-cloudflare-page-cache' ) );
+					}
+
+					if ( ! wpmmVars.isWPSCActive ) {
+						return activatePlugin( wpmmVars.isWPSCProInstalled ? 'wp-super-page-cache-pro' : 'wp-cloudflare-page-cache' );
+					}
+				} );
 		}
 
 		if ( otterBlockCheckbox.length && otterBlockCheckbox.is( ':checked' ) ) {
@@ -637,7 +651,7 @@ jQuery( function( $ ) {
 					updateSDKOptions();
 					return activatePlugin( 'otter-blocks' );
 				} );
-		} else if ( ! wpmmVars.isOtterActivated ) {
+		} else if ( ! wpmmVars.isOtterActive ) {
 			return activatePlugin( 'otter-blocks' );
 		}
 
@@ -689,6 +703,9 @@ jQuery( function( $ ) {
 				return $.get( wpmmVars.otterActivationLink );
 			case 'optimole-wp':
 				return $.get( wpmmVars.optimoleActivationLink );
+			case 'wp-super-page-cache-pro':
+			case 'wp-cloudflare-page-cache':
+				return $.get( wpmmVars.wpscActivationLink );
 			default:
 				break;
 		}

--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -168,6 +168,9 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 						'isOtterActive'          => is_plugin_active( 'otter-blocks/otter-blocks.php' ),
 						'isOptimoleInstalled'    => file_exists( ABSPATH . 'wp-content/plugins/optimole-wp/optimole-wp.php' ),
 						'isOptimoleActive'       => is_plugin_active( 'optimole-wp/optimole-wp.php' ),
+						'isWPSCInstalled'        => file_exists( ABSPATH . 'wp-content/plugins/wp-cloudflare-page-cache/wp-cloudflare-super-page-cache.php' ) || file_exists( ABSPATH . 'wp-content/plugins/wp-super-page-cache-pro/wp-cloudflare-super-page-cache-pro.php' ),
+						'isWPSCActive'           => is_plugin_active( 'wp-cloudflare-page-cache/wp-cloudflare-super-page-cache.php' ) || is_plugin_active( 'wp-super-page-cache-pro/wp-cloudflare-super-page-cache-pro.php' ),
+						'isWPSCProInstalled'     => file_exists( ABSPATH . 'wp-content/plugins/wp-super-page-cache-pro/wp-cloudflare-super-page-cache-pro.php' ),
 						'errorString'            => __( 'Something went wrong, please try again.', 'wp-maintenance-mode' ),
 						'loadingString'          => __( 'Doing some magic...', 'wp-maintenance-mode' ),
 						'importingText'          => __( 'Importing', 'wp-maintenance-mode' ),
@@ -195,6 +198,16 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 								'plugin_status' => 'all',
 								'paged'         => '1',
 								'_wpnonce'      => wp_create_nonce( 'activate-plugin_optimole-wp/optimole-wp.php' ),
+							),
+							esc_url( network_admin_url( 'plugins.php' ) )
+						),
+						'wpscActivationLink'     => add_query_arg(
+							array(
+								'action'        => 'activate',
+								'plugin'        => rawurlencode( file_exists( ABSPATH . 'wp-content/plugins/wp-super-page-cache-pro/wp-cloudflare-super-page-cache-pro.php' ) ? 'wp-super-page-cache-pro/wp-cloudflare-super-page-cache-pro.php' : 'wp-cloudflare-page-cache/wp-cloudflare-super-page-cache.php' ),
+								'plugin_status' => 'all',
+								'paged'         => '1',
+								'_wpnonce'      => wp_create_nonce( file_exists( ABSPATH . 'wp-content/plugins/wp-super-page-cache-pro/wp-cloudflare-super-page-cache-pro.php' ) ? 'activate-plugin_wp-super-page-cache-pro/wp-cloudflare-super-page-cache-pro.php' : 'activate-plugin_wp-cloudflare-page-cache/wp-cloudflare-super-page-cache.php' ),
 							),
 							esc_url( network_admin_url( 'plugins.php' ) )
 						),

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,12 @@ $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 error_log( var_export ( $_tests_dir, true) );
 
+$polyfills_path = dirname( dirname( __FILE__ ) ) . '/vendor/yoast/phpunit-polyfills';
+
+if ( file_exists( $polyfills_path . '/phpunitpolyfills-autoload.php' ) && ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $polyfills_path );
+}
+
 if ( ! $_tests_dir ) {
     $_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }

--- a/views/wizard.php
+++ b/views/wizard.php
@@ -98,6 +98,35 @@ $default_templates = array(
 								wpmm_translated_string_allowed_html(),
 							);
 							?>
+						</p>
+					</div>
+				<?php } ?>
+				<?php if ( ! is_plugin_active( 'wp-cloudflare-page-cache/wp-cloudflare-super-page-cache.php' ) && ! is_plugin_active( 'wp-super-page-cache-pro/wp-cloudflare-super-page-cache-pro.php' ) ) { ?>
+					<div class="optimole-upsell">
+						<div class="optimole-upsell-container">
+							<span class="components-checkbox-control__input-container">
+								<input id="wizard-wpsc-checkbox" type="checkbox" class="components-checkbox-control__input" checked>
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="presentation" class="components-checkbox-control__checked" aria-hidden="true" focusable="false"><path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"></path></svg>
+							</span>
+							<label for="wizard-wpsc-checkbox">
+								<?php esc_html_e( 'Accelerate your website performance', 'wp-maintenance-mode' ); ?>
+							</label>
+						</div>
+						<p class="description">
+							<?php
+							echo wp_kses(
+								sprintf(
+									// translators: %1$s is a description, %2$s is the Super Page Cache URL, %3$s is the plugin name, %4$s is description text.
+									'%1$s <a href="%2$s" target="_blank">%3$s</a> %4$s',
+									__( 'Speed up your pages by 60-80% with intelligent caching. Achieve faster load times and better search rankings automatically, with', 'wp-maintenance-mode' ),
+									esc_url( 'https://wordpress.org/plugins/wp-cloudflare-page-cache/' ),
+									__( 'Super Page Cache', 'wp-maintenance-mode' ),
+									__( 'plugin installed and activated automatically.', 'wp-maintenance-mode' ),
+								),
+								wpmm_translated_string_allowed_html(),
+							);
+							?>
+						</p>
 					</div>
 				<?php } ?>
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

This adds a separate Super Page Cache upsell to the LightStart onboarding wizard without changing the existing Optimole option.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

Fresh install state
- Open the onboarding wizard with Super Page Cache not installed.
- Confirm the new Super Page Cache option is visible and checked by default.
- Choose a template and continue.
- Verify Super Page Cache is installed and activated.

Installed but inactive state
- Install Super Page Cache manually but leave it inactive.
- Open the onboarding wizard.
- Confirm the Super Page Cache option is still visible.
- Choose a template and continue.
- Verify the plugin is activated without attempting a fresh install.

Already active state
- Activate Super Page Cache before opening the wizard.
- Open the onboarding wizard.
- Confirm the Super Page Cache option is not shown.

Optimole regression check
- Repeat the same basic onboarding flow with Optimole not installed.
- Confirm the existing Optimole option still appears and still installs/activates correctly.

Combined flow check
- With both Optimole and Super Page Cache inactive or missing, run the wizard with both options checked.
- Verify both plugins complete successfully and the template import still finishes as expected.

Skip behavior
- Leave the WPSC checkbox unchecked and continue through the wizard.
- Verify Super Page Cache is not installed or activated.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/WP-Cloudflare-Super-Page-Cache/issues/311.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
