### PR TITLE
Sync branch: merge master into development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
 
 version: 2
+
 updates:
 
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.3.55",
+            "version": "3.3.58",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "bd601798d209a4bc5962d2a19a22dc6dddf341cc"
+                "reference": "d6807c0b7308e323bd77cced667dee3f2d5e6a82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/bd601798d209a4bc5962d2a19a22dc6dddf341cc",
-                "reference": "bd601798d209a4bc5962d2a19a22dc6dddf341cc",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/d6807c0b7308e323bd77cced667dee3f2d5e6a82",
+                "reference": "d6807c0b7308e323bd77cced667dee3f2d5e6a82",
                 "shasum": ""
             },
             "require-dev": {
@@ -43,9 +43,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.55"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.58"
             },
-            "time": "2026-07-20T10:57:27+00:00"
+            "time": "2026-07-29T08:38:52+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Restores the `master` → `development` sync so release PR #534 can merge.

The automated **Sync branches** workflow failed with a 409 merge conflict after the themeisle-sdk bump landed on `master` ([run 30452282623](https://github.com/Codeinwp/wp-maintenance-mode/actions/runs/30452282623)), leaving `development` 3 commits behind and #534 in a CONFLICTING state.

### How the conflict was resolved

The only conflict was the `codeinwp/themeisle-sdk` entry in `composer.lock`: `development` had 3.3.56, `master` has 3.3.58 from #533.

- `composer.lock` — kept **development's** lock and took only the themeisle-sdk stanza from `master` (3.3.56 → 3.3.58). Taking master's file wholesale would have reverted development's dev-dependency set (phpstan, php-stubs/wordpress-stubs, phpunit ^9.6) that came with the testing setup. The lock parses, `composer validate` is clean, and `content-hash` still matches development's `composer.json`, which the merge kept unchanged.
- `.github/dependabot.yml` — taken from `master`; it adds `target-branch: "development"`, so future dependency bumps in this repo target `development` and this split should not recur.

No source files are touched.
